### PR TITLE
Add The Freedom Deer project group as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "The Freedom Deer"]
+	path = The Freedom Deer
+	url = https://github.com/lqwdev/ai339-project


### PR DESCRIPTION
Adding group project repository for 'The Freedom Deer' as a git submodule.
We chose to develop our project in our own repo so we created a link to our repo from the main repo instead.